### PR TITLE
Fixed build failure, occuring due to backwards incompatible changes added in release v9.32 of nimbus-jose-jwt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nimbus-jose-jwt_aws-kms-extension
 
 This library package is an **extension of [nimbus-jose-jwt](https://connect2id.com/products/nimbus-jose-jwt)** library.
-It is compatible with version 9.+ of nimbus-jose-jwt. It provides JWE based encrypters/decrypters and JWS based
+It is compatible with version >=9.0,<=9.31 of nimbus-jose-jwt. It provides JWE based encrypters/decrypters and JWS based
 signers/verifiers for doing operations with cryptographic keys stores in AWS KMS. This library requires Java 8 or above.
 
 # Usage

--- a/nimbus-jose-jwt_aws-kms-extension/build.gradle
+++ b/nimbus-jose-jwt_aws-kms-extension/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
-    api 'com.nimbusds:nimbus-jose-jwt:[9,10)'
+    api 'com.nimbusds:nimbus-jose-jwt:[9,9.31]'
 
     // These dependencies is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.amazonaws:aws-java-sdk-kms:[1.12, 2)'


### PR DESCRIPTION
Fixed build failure, occuring due to backwards incompatible changes added in release v9.32 of nimbus-jose-jwt.
nimbus-jose-jwt has added 'aad' parameter in both JWEEncryter and JWEDecrypter classes in the release (Ref: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/9.32/src/main/java/com/nimbusds/jose/JWEEncrypter.java).  Updated the dependency version of nimbus-jose-jwt to resolve the build failure.
…

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
