### PR TITLE
Removed upper bound restriction from com.google.guava:guava

### DIFF
--- a/nimbus-jose-jwt_aws-kms-extension/build.gradle
+++ b/nimbus-jose-jwt_aws-kms-extension/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'software.amazon.lynx'
-version = '1.1.0'
+version = '1.1.1'
 
 java {
     toolchain {
@@ -34,7 +34,7 @@ dependencies {
     // These dependencies is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.amazonaws:aws-java-sdk-kms:[1.12, 2)'
     implementation 'commons-cli:commons-cli:[1.4, 2)'
-    implementation 'com.google.guava:guava:[30,31)'
+    implementation 'com.google.guava:guava:[30,)'
 
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.+'


### PR DESCRIPTION
Removed upper bound restriction from com.google.guava:guava, as it supports indefinite backward compatibility and older versions are not available in MavenCentral anymore.

Details about indefinite backward compatibility is covered in point 2 here: https://github.com/google/guava/blob/master/README.md#important-warnings. Moreover details are present at: https://github.com/google/guava/wiki/Compatibility
…

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
