### PR TITLE
Modified KmsAsymmetricSigningCryptoProvider to accept RFC-compliant JWSAlgorithm types

### DIFF
--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricSigner.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricSigner.java
@@ -65,7 +65,7 @@ public class KmsAsymmetricSigner extends KmsAsymmetricSigningCryptoProvider impl
                     .withKeyId(getPrivateKeyId())
                     .withMessageType(getMessageType())
                     .withMessage(message)
-                    .withSigningAlgorithm(header.getAlgorithm().toString()));
+                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(header.getAlgorithm()).toString()));
         } catch (NotFoundException | DisabledException | KeyUnavailableException | InvalidKeyUsageException
                 | KMSInvalidStateException e) {
             throw new RemoteKeySourceException("An exception was thrown from KMS due to invalid key.", e);

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricVerifier.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricVerifier.java
@@ -105,7 +105,7 @@ public class KmsAsymmetricVerifier
         try {
             verifyResult = getKms().verify(new VerifyRequest()
                     .withKeyId(getPrivateKeyId())
-                    .withSigningAlgorithm(header.getAlgorithm().toString())
+                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(header.getAlgorithm()).toString())
                     .withMessageType(getMessageType())
                     .withMessage(message)
                     .withSignature(ByteBuffer.wrap(signature.decode())));
@@ -120,4 +120,5 @@ public class KmsAsymmetricVerifier
 
         return verifyResult.isSignatureValid();
     }
+
 }

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
@@ -75,6 +75,25 @@ public abstract class KmsAsymmetricSigningCryptoProvider extends BaseJWSProvider
                     .put(JWSAlgorithm.ES256, MessageDigestAlgorithms.SHA_256)
                     .put(JWSAlgorithm.ES384, MessageDigestAlgorithms.SHA_384)
                     .put(JWSAlgorithm.ES512, MessageDigestAlgorithms.SHA_512)
+                    // backwards compatibility for KMS-defined algorithm strings
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256.toString()),
+                            MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384.toString()),
+                            MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512.toString()),
+                            MessageDigestAlgorithms.SHA_512)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_256.toString()),
+                            MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_384.toString()),
+                            MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_512.toString()),
+                            MessageDigestAlgorithms.SHA_512)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_256.toString()),
+                            MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_384.toString()),
+                            MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_512.toString()),
+                            MessageDigestAlgorithms.SHA_512)
                     .build();
 
     public static final Map<JWSAlgorithm, SigningAlgorithmSpec> JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC =
@@ -88,6 +107,25 @@ public abstract class KmsAsymmetricSigningCryptoProvider extends BaseJWSProvider
                     .put(JWSAlgorithm.ES256, SigningAlgorithmSpec.ECDSA_SHA_256)
                     .put(JWSAlgorithm.ES384, SigningAlgorithmSpec.ECDSA_SHA_384)
                     .put(JWSAlgorithm.ES512, SigningAlgorithmSpec.ECDSA_SHA_512)
+                    // backwards compatibility for KMS-defined algorithm strings
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256.toString()),
+                            SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384.toString()),
+                            SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512.toString()),
+                            SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_256.toString()),
+                            SigningAlgorithmSpec.RSASSA_PSS_SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_384.toString()),
+                            SigningAlgorithmSpec.RSASSA_PSS_SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_512.toString()),
+                            SigningAlgorithmSpec.RSASSA_PSS_SHA_512)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_256.toString()),
+                            SigningAlgorithmSpec.ECDSA_SHA_256)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_384.toString()),
+                            SigningAlgorithmSpec.ECDSA_SHA_384)
+                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_512.toString()),
+                            SigningAlgorithmSpec.ECDSA_SHA_512)
                     .build();
     /**
      * The supported JWS algorithms (alg).

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
@@ -107,7 +107,7 @@ public abstract class KmsAsymmetricSigningCryptoProvider extends BaseJWSProvider
                     .put(JWSAlgorithm.ES256, SigningAlgorithmSpec.ECDSA_SHA_256)
                     .put(JWSAlgorithm.ES384, SigningAlgorithmSpec.ECDSA_SHA_384)
                     .put(JWSAlgorithm.ES512, SigningAlgorithmSpec.ECDSA_SHA_512)
-                    // backwards compatibility for KMS-defined algorithm strings
+                    // Compatibility for KMS-defined algorithm strings
                     .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256.toString()),
                             SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256)
                     .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384.toString()),
@@ -130,7 +130,7 @@ public abstract class KmsAsymmetricSigningCryptoProvider extends BaseJWSProvider
     /**
      * The supported JWS algorithms (alg).
      * <p>
-     * Note: We accept the algorithms defined in RFC-7518 and translate these internally to KMS strings.
+     * Note: We accept both the algorithms defined in RFC-7518 and KMS-defined strings.
      *
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7518#section-3.1">RFC-7518 Section 3.1</a>
      * @see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html">

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProvider.java
@@ -66,33 +66,40 @@ public abstract class KmsAsymmetricSigningCryptoProvider extends BaseJWSProvider
 
     public static final Map<JWSAlgorithm, String> JWS_ALGORITHM_TO_MESSAGE_DIGEST_ALGORITHM =
             ImmutableMap.<JWSAlgorithm, String>builder()
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256.toString()),
-                            MessageDigestAlgorithms.SHA_256)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384.toString()),
-                            MessageDigestAlgorithms.SHA_384)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512.toString()),
-                            MessageDigestAlgorithms.SHA_512)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_256.toString()),
-                            MessageDigestAlgorithms.SHA_256)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_384.toString()),
-                            MessageDigestAlgorithms.SHA_384)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_512.toString()),
-                            MessageDigestAlgorithms.SHA_512)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_256.toString()),
-                            MessageDigestAlgorithms.SHA_256)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_384.toString()),
-                            MessageDigestAlgorithms.SHA_384)
-                    .put(JWSAlgorithm.parse(SigningAlgorithmSpec.ECDSA_SHA_512.toString()),
-                            MessageDigestAlgorithms.SHA_512)
+                    .put(JWSAlgorithm.RS256, MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.RS384, MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.RS512, MessageDigestAlgorithms.SHA_512)
+                    .put(JWSAlgorithm.PS256, MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.PS384, MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.PS512, MessageDigestAlgorithms.SHA_512)
+                    .put(JWSAlgorithm.ES256, MessageDigestAlgorithms.SHA_256)
+                    .put(JWSAlgorithm.ES384, MessageDigestAlgorithms.SHA_384)
+                    .put(JWSAlgorithm.ES512, MessageDigestAlgorithms.SHA_512)
                     .build();
 
+    public static final Map<JWSAlgorithm, SigningAlgorithmSpec> JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC =
+            ImmutableMap.<JWSAlgorithm, SigningAlgorithmSpec>builder()
+                    .put(JWSAlgorithm.RS256, SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256)
+                    .put(JWSAlgorithm.RS384, SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384)
+                    .put(JWSAlgorithm.RS512, SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512)
+                    .put(JWSAlgorithm.PS256, SigningAlgorithmSpec.RSASSA_PSS_SHA_256)
+                    .put(JWSAlgorithm.PS384, SigningAlgorithmSpec.RSASSA_PSS_SHA_384)
+                    .put(JWSAlgorithm.PS512, SigningAlgorithmSpec.RSASSA_PSS_SHA_512)
+                    .put(JWSAlgorithm.ES256, SigningAlgorithmSpec.ECDSA_SHA_256)
+                    .put(JWSAlgorithm.ES384, SigningAlgorithmSpec.ECDSA_SHA_384)
+                    .put(JWSAlgorithm.ES512, SigningAlgorithmSpec.ECDSA_SHA_512)
+                    .build();
     /**
      * The supported JWS algorithms (alg).
      * <p>
-     * Note: We are using KMS prescribed algorithm names here.
-     * Ref: https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html#key-spec-rsa-sign
+     * Note: We accept the algorithms defined in RFC-7518 and translate these internally to KMS strings.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7518#section-3.1">RFC-7518 Section 3.1</a>
+     * @see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html">
+     *     AWS Developer Guide - Asymmetric key specs
+     *     </a>
      */
-    public static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = JWS_ALGORITHM_TO_MESSAGE_DIGEST_ALGORITHM.keySet();
+    public static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.keySet();
 
     protected KmsAsymmetricSigningCryptoProvider(
             @NonNull final AWSKMS kms, @NonNull final String privateKeyId, @NonNull final MessageType messageType) {

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricRsaSsaSignerTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricRsaSsaSignerTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsAsymmetricSigningCryptoProvider.JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
@@ -90,7 +91,7 @@ public class KmsAsymmetricRsaSsaSignerTest {
         @BeforeEach
         @SneakyThrows
         void beforeEach() {
-            testJweHeader = new JWSHeader.Builder(random.nextObject(JWSAlgorithm.class)).build();
+            testJweHeader = new JWSHeader.Builder(JWSAlgorithm.PS512).build();
 
             testSigningInput = new byte[random.nextInt(512)];
             random.nextBytes(testSigningInput);
@@ -118,7 +119,7 @@ public class KmsAsymmetricRsaSsaSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenThrow(mockInvalidSigningException);
                 return mockInvalidSigningException;
             }
@@ -149,7 +150,7 @@ public class KmsAsymmetricRsaSsaSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenThrow(mockTemporaryKmsException);
                 return mockTemporaryKmsException;
             }
@@ -183,7 +184,7 @@ public class KmsAsymmetricRsaSsaSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenReturn(mockSignResult);
 
                 final var testSignatureByteBuffer = ByteBuffer.allocate(random.nextInt(512));

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricRsaSsaVerifierTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricRsaSsaVerifierTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsAsymmetricSigningCryptoProvider.JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
@@ -134,7 +135,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
 
         @BeforeEach
         void beforeEach() {
-            testJweHeader = new JWSHeader.Builder(random.nextObject(JWSAlgorithm.class))
+            testJweHeader = new JWSHeader.Builder(JWSAlgorithm.PS512)
                     .criticalParams(testCriticalHeaders)
                     .build();
 
@@ -198,7 +199,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -231,7 +232,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -265,7 +266,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -294,7 +295,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -325,7 +326,7 @@ public class KmsAsymmetricRsaSsaVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricSignerTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricSignerTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsAsymmetricSigningCryptoProvider.JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
@@ -90,7 +91,7 @@ public class KmsAsymmetricSignerTest {
         @BeforeEach
         @SneakyThrows
         void beforeEach() {
-            testJweHeader = new JWSHeader.Builder(random.nextObject(JWSAlgorithm.class)).build();
+            testJweHeader = new JWSHeader.Builder(JWSAlgorithm.PS512).build();
 
             testSigningInput = new byte[random.nextInt(512)];
             random.nextBytes(testSigningInput);
@@ -118,7 +119,7 @@ public class KmsAsymmetricSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenThrow(mockInvalidSigningException);
                 return mockInvalidSigningException;
             }
@@ -149,7 +150,7 @@ public class KmsAsymmetricSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenThrow(mockTemporaryKmsException);
                 return mockTemporaryKmsException;
             }
@@ -183,7 +184,7 @@ public class KmsAsymmetricSignerTest {
                                 .withKeyId(testPrivateKeyId)
                                 .withMessageType(testMessageType)
                                 .withMessage(mockMessage)
-                                .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())))
+                                .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())))
                         .thenReturn(mockSignResult);
 
                 final var testSignatureByteBuffer = ByteBuffer.allocate(random.nextInt(512));

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricVerifierTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsAsymmetricVerifierTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsAsymmetricSigningCryptoProvider.JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
@@ -134,7 +135,7 @@ public class KmsAsymmetricVerifierTest {
 
         @BeforeEach
         void beforeEach() {
-            testJweHeader = new JWSHeader.Builder(random.nextObject(JWSAlgorithm.class))
+            testJweHeader = new JWSHeader.Builder(JWSAlgorithm.PS512)
                     .criticalParams(testCriticalHeaders)
                     .build();
 
@@ -198,7 +199,7 @@ public class KmsAsymmetricVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -231,7 +232,7 @@ public class KmsAsymmetricVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -265,7 +266,7 @@ public class KmsAsymmetricVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -294,7 +295,7 @@ public class KmsAsymmetricVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))
@@ -325,7 +326,7 @@ public class KmsAsymmetricVerifierTest {
                     when(mockAwsKms
                             .verify(new VerifyRequest()
                                     .withKeyId(testPrivateKeyId)
-                                    .withSigningAlgorithm(testJweHeader.getAlgorithm().toString())
+                                    .withSigningAlgorithm(JWS_ALGORITHM_TO_SIGNING_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()).toString())
                                     .withMessageType(testMessageType)
                                     .withMessage(mockMessage)
                                     .withSignature(ByteBuffer.wrap(testSignature.decode()))))

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricRSASSAProviderTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricRSASSAProviderTest.java
@@ -112,9 +112,7 @@ public class KmsAsymmetricRSASSAProviderTest {
 
             @BeforeEach
             void beforeEach() {
-                testJwsHeader = new JWSHeader.Builder(
-                        JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_512.toString()))
-                        .build();
+                testJwsHeader = new JWSHeader.Builder(JWSAlgorithm.PS512).build();
                 testSigningInputBytes = "Test Payload / ٹیسٹ پیلوڈ".getBytes(StandardCharsets.UTF_8);
                 expectedMessage = ByteBuffer.wrap(testSigningInputBytes);
             }

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProviderTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsAsymmetricSigningCryptoProviderTest.java
@@ -112,9 +112,7 @@ public class KmsAsymmetricSigningCryptoProviderTest {
 
             @BeforeEach
             void beforeEach() {
-                testJwsHeader = new JWSHeader.Builder(
-                        JWSAlgorithm.parse(SigningAlgorithmSpec.RSASSA_PSS_SHA_512.toString()))
-                        .build();
+                testJwsHeader = new JWSHeader.Builder(JWSAlgorithm.PS512).build();
                 testSigningInputBytes = "Test Payload / ٹیسٹ پیلوڈ".getBytes(StandardCharsets.UTF_8);
                 expectedMessage = ByteBuffer.wrap(testSigningInputBytes);
             }


### PR DESCRIPTION
A possible approach for https://github.com/amzn/nimbus-jose-jwt_aws-kms-extension/issues/14.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
