### PR TITLE
Modified KmsDefaultEncryptionCryptoProvider to accept RFC-compliant J…

### DIFF
--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultEncrypter.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultEncrypter.java
@@ -34,7 +34,6 @@ import com.nimbusds.jose.JWEEncrypter;
 import com.nimbusds.jose.JWEHeader;
 import com.nimbusds.jose.RemoteKeySourceException;
 import com.nimbusds.jose.aws.kms.crypto.impl.KmsDefaultEncryptionCryptoProvider;
-import com.nimbusds.jose.aws.kms.crypto.impl.KmsSymmetricCryptoProvider;
 import com.nimbusds.jose.aws.kms.crypto.utils.JWEHeaderUtil;
 import com.nimbusds.jose.aws.kms.exceptions.TemporaryJOSEException;
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
@@ -88,7 +87,7 @@ public class KmsDefaultEncrypter extends KmsDefaultEncryptionCryptoProvider impl
         try {
             return getKms().encrypt(new EncryptRequest()
                     .withKeyId(keyId)
-                    .withEncryptionAlgorithm(alg.getName())
+                    .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(alg))
                     .withPlaintext(ByteBuffer.wrap(cek.getEncoded()))
                     .withEncryptionContext(encryptionContext));
         } catch (NotFoundException | DisabledException | InvalidKeyUsageException

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsDefaultEncryptionCryptoProvider.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/impl/KmsDefaultEncryptionCryptoProvider.java
@@ -62,13 +62,24 @@ public abstract class KmsDefaultEncryptionCryptoProvider extends PublicBaseJWEPr
     /**
      * The supported JWE algorithms (alg) by the AWS crypto provider class.
      * <p>
-     * Note: We are using KMS prescribed algorithm names here.
-     * Ref: https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html
+     * Note: We accept both the algorithms defined in RFC-7518 and KMS-defined strings.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7518#section-4.1">RFC-7518 Section 4.1</a>
+     * @see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html"> KMS Asymmetric key specs </a>
      */
     public static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS = ImmutableSet.of(
             JWEAlgorithm.parse(EncryptionAlgorithmSpec.SYMMETRIC_DEFAULT.name()),
             JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1.name()),
-            JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.name()));
+            JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.name()),
+            JWEAlgorithm.RSA_OAEP_256,
+            JWEAlgorithm.RSA_OAEP);
+
+    public static final Map<JWEAlgorithm, String> JWE_TO_KMS_ALGORITHM_SPEC = ImmutableMap.<JWEAlgorithm, String>builder()
+            .put(JWEAlgorithm.parse(EncryptionAlgorithmSpec.SYMMETRIC_DEFAULT.name()), EncryptionAlgorithmSpec.SYMMETRIC_DEFAULT.name())
+            .put(JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1.name()), EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1.name())
+            .put(JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.name()), EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.name())
+            .put(JWEAlgorithm.RSA_OAEP_256, EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.name())
+            .put(JWEAlgorithm.RSA_OAEP, EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1.name())
+            .build();
 
     /**
      * The supported JWE encryption methods (enc) by the AWS crypto provider class.

--- a/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/utils/JWEDecrypterUtil.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/main/java/com/nimbusds/jose/aws/kms/crypto/utils/JWEDecrypterUtil.java
@@ -26,6 +26,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.experimental.UtilityClass;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsDefaultEncryptionCryptoProvider.JWE_TO_KMS_ALGORITHM_SPEC;
+
 /**
  * Utility class containing JWE decryption related methods.
  */
@@ -69,7 +71,7 @@ public class JWEDecrypterUtil {
             return kms.decrypt(new DecryptRequest()
                     .withEncryptionContext(encryptionContext)
                     .withKeyId(keyId)
-                    .withEncryptionAlgorithm(alg.getName())
+                    .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(alg))
                     .withCiphertextBlob(ByteBuffer.wrap(encryptedKey.decode())));
         } catch (NotFoundException | DisabledException | InvalidKeyUsageException | KeyUnavailableException
                  | KMSInvalidStateException e) {

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultDecrypterTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultDecrypterTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsDefaultEncryptionCryptoProvider.JWE_TO_KMS_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -141,7 +142,7 @@ public class KmsDefaultDecrypterTest {
             @SneakyThrows
             void beforeEach() {
                 testJweHeader = new JWEHeader.Builder(
-                        JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString()),
+                        JWEAlgorithm.RSA_OAEP_256,
                         EncryptionMethod.A256GCM)
                         .criticalParams(ImmutableSet.of("test-critical-header"))
                         .build();
@@ -228,7 +229,7 @@ public class KmsDefaultDecrypterTest {
                     when(mockAwsKms
                             .decrypt(new DecryptRequest()
                                     .withEncryptionContext(testEncryptionContext)
-                                    .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                    .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                     .withKeyId(testKeyId)
                                     .withCiphertextBlob(ByteBuffer.wrap(testEncryptedKey.decode()))))
                             .thenReturn(testDecryptResult);

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultEncrypterTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/KmsDefaultEncrypterTest.java
@@ -16,6 +16,7 @@
 
 package com.nimbusds.jose.aws.kms.crypto;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsDefaultEncryptionCryptoProvider.JWE_TO_KMS_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,7 +36,6 @@ import com.amazonaws.services.kms.model.DependencyTimeoutException;
 import com.amazonaws.services.kms.model.DisabledException;
 import com.amazonaws.services.kms.model.EncryptRequest;
 import com.amazonaws.services.kms.model.EncryptResult;
-import com.amazonaws.services.kms.model.EncryptionAlgorithmSpec;
 import com.amazonaws.services.kms.model.InvalidGrantTokenException;
 import com.amazonaws.services.kms.model.InvalidKeyUsageException;
 import com.amazonaws.services.kms.model.KMSInternalException;
@@ -104,7 +104,7 @@ class KmsDefaultEncrypterTest {
         void beforeEach() {
             random.nextBytes(testClearText);
             testJweHeader = new JWEHeader.Builder(
-                    JWEAlgorithm.parse(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString()),
+                    JWEAlgorithm.RSA_OAEP_256,
                     EncryptionMethod.A256GCM)
                     .build();
             ReflectionSupport.invokeMethod(
@@ -123,7 +123,7 @@ class KmsDefaultEncrypterTest {
                 when(mockAwsKms
                         .encrypt(new EncryptRequest()
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withPlaintext(any())
                                 .withEncryptionContext(testEncryptionContext)))
                         .thenThrow(invalidKeyException);
@@ -154,7 +154,7 @@ class KmsDefaultEncrypterTest {
                 when(mockAwsKms
                         .encrypt(new EncryptRequest()
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withPlaintext(any())
                                 .withEncryptionContext(testEncryptionContext)))
                         .thenThrow(temporaryKMSException);
@@ -204,7 +204,7 @@ class KmsDefaultEncrypterTest {
                 when(mockAwsKms
                         .encrypt(new EncryptRequest()
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withPlaintext(ByteBuffer.wrap(cekBytes))
                                 .withEncryptionContext(testEncryptionContext)))
                         .thenReturn(testEncryptedKey);

--- a/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/utils/JWEDecrypterUtilTest.java
+++ b/nimbus-jose-jwt_aws-kms-extension/src/test/java/com/nimbusds/jose/aws/kms/crypto/utils/JWEDecrypterUtilTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.nimbusds.jose.aws.kms.crypto.impl.KmsDefaultEncryptionCryptoProvider.JWE_TO_KMS_ALGORITHM_SPEC;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -72,7 +73,7 @@ public class JWEDecrypterUtilTest {
             testKeyId = random.nextObject(String.class);
             testEncryptionContext = random.nextObject(Map.class);
             testJweHeader = new JWEHeader.Builder(
-                    JWEAlgorithm.parse(EncryptionAlgorithmSpec.SYMMETRIC_DEFAULT.toString()),
+                    JWEAlgorithm.RSA_OAEP_256,
                     EncryptionMethod.A256GCM)
                     .build();
         }
@@ -87,7 +88,7 @@ public class JWEDecrypterUtilTest {
                         .decrypt(new DecryptRequest()
                                 .withEncryptionContext(testEncryptionContext)
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withCiphertextBlob(ByteBuffer.wrap(testEncryptedKey.decode()))))
                         .thenThrow(invalidKeyException);
 
@@ -120,7 +121,7 @@ public class JWEDecrypterUtilTest {
                         .decrypt(new DecryptRequest()
                                 .withEncryptionContext(testEncryptionContext)
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withCiphertextBlob(ByteBuffer.wrap(testEncryptedKey.decode()))))
                         .thenThrow(temporaryKMSException);
 
@@ -158,7 +159,7 @@ public class JWEDecrypterUtilTest {
                         .decrypt(new DecryptRequest()
                                 .withEncryptionContext(testEncryptionContext)
                                 .withKeyId(testKeyId)
-                                .withEncryptionAlgorithm(testJweHeader.getAlgorithm().getName())
+                                .withEncryptionAlgorithm(JWE_TO_KMS_ALGORITHM_SPEC.get(testJweHeader.getAlgorithm()))
                                 .withCiphertextBlob(ByteBuffer.wrap(testEncryptedKey.decode()))))
                         .thenReturn(testDecryptResult);
 


### PR DESCRIPTION
…WEAlgorithm types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Testing : Created a JWE using original Nimbus library(without KMS) using public key. Used that payload to run `KmsDefaultJweCompactDecrypterScript` and verified decrypted payload with original payload.
